### PR TITLE
Removed coloured SSH outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,9 +283,9 @@ You can list the cache locations and the names of the files using these commands
 
 ## Finding all active movers for WAN or local dcap accesses for a VO
 
-Look at the dc<sub>get</sub><sub>pool</sub><sub>movers</sub>.sh command. If we want to see all active dcap movers (default) queue:
+Look at the dc<sub>get</sub><sub>pool</sub><sub>movers</sub>.sh command. If we want to see all active dcap movers (regular) queue:
 
-    dc_get_pool_list.sh | grep cms | dc_get_pool_movers.sh -q default
+    dc_get_pool_list.sh | grep cms | dc_get_pool_movers.sh -q regular
 
 ## Finding a number of movers and selectively kill them based on which files they are accessing
 

--- a/bin/dc_utils_lib.sh
+++ b/bin/dc_utils_lib.sh
@@ -135,6 +135,8 @@ execute_cmdfile() {
        fi
        ((tries=$tries+1))
        ssh $sshoptions 2>${tmpfile}.err > $tmpfile <$cmdfile
+       # remove colours
+       sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" -i $tmpfile
        egrep -q 'admin  *>  *logoff' $tmpfile
        callok=$?
     done
@@ -147,6 +149,9 @@ execute_cmdfile() {
 
     #clean out the leading ^M
     sed -i -e 's/\cM\(.*\)/\1/' $tmpfile
+
+    # remove colours
+    sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" -i $tmpfile
 
     eval $fileref=$tmpfile
     return 0


### PR DESCRIPTION
Since the dCache 2.10 admin door produces coloured outputs the dcache-shellutils needs to remove those macros to properly work
