### PR TITLE
Disable SSH compression by default

### DIFF
--- a/bin/dc_utils_lib.sh
+++ b/bin/dc_utils_lib.sh
@@ -41,7 +41,7 @@ fi
 # introduce a means for adding user specified options, e.g. NoHostAuthenticationForLocalhost
 # for SSH tunnels
 
-sshoptions=" -T -o NoHostAuthenticationForLocalhost=yes -l admin -p $DCACHEADMINPORT $DCACHEADMINHOST"
+sshoptions=" -T -o Compression=no -o NoHostAuthenticationForLocalhost=yes -l admin -p $DCACHEADMINPORT $DCACHEADMINHOST"
 
 # returns 0 for OK, i.e. the poolname exists, otherwise 1
 check_poolname() {


### PR DESCRIPTION
SSH connctions to the dCache admin cell do not work when Compression
is enabled. Therefore, it makes sense to have `Compression no` by
default when connecting through SSH.

Future updates may contain using alternative of `ssh_config` file
or including custom SSH options.